### PR TITLE
Fixes: error on AKS-deprecated k8s version, json parse bug, nvidia version

### DIFF
--- a/kubectl.py
+++ b/kubectl.py
@@ -24,7 +24,7 @@ def get_services(c):
 
 @task
 def install_nvidia(c):
-    c.run("kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.11/nvidia-device-plugin.yml", pty=True)
+    c.run("kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.12/nvidia-device-plugin.yml", pty=True)
 
 @task
 def install_blob(c):

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,7 @@ def login(c):
 
 def _registered_container_services(c):
     cmd_results = c.run(f"az provider show -n Microsoft.ContainerService", pty=True)
-    cmd_dict = json.loads(cmd_results.stdout)
+    cmd_dict = json.loads(cmd_results.stdout.strip('\x1b[0m'))
     return cmd_dict["registrationState"] == "Registered"
 
 
@@ -134,7 +134,7 @@ def aks_create(
         f"--node-count {node_count} "
         f"--generate-ssh-keys "
         f"-s  {vm_type} "
-        f"--kubernetes-version 1.11.8 "
+        f"--kubernetes-version 1.13.10 "
     )  
     c.run(cmd, pty=True)
 


### PR DESCRIPTION
**This pull request fixes three bugs:**

1. It seems the current default version of k8s is deprecated in AKS so I incremented the version. Error was:
> Operation failed with status: 'Bad Request'. Details: Version 1.11.8 is not supported



2. There is a JSON parse error (at least on some systems) that leaves some ANSI character ("^[[0m") at the end of the string so I am stripping that off the end and have tested it to make sure it succeeds. Error was:
> Traceback (most recent call last):
>   File "/workspace/tasks.py", line 85, in register_container_services
>     if not _registered_container_services(c):
>   File "/workspace/tasks.py", line 76, in _registered_container_services
>     cmd_dict = json.loads(cmd_results.stdout)
>   File "/opt/conda/envs/py36/lib/python3.6/json/__init__.py", line 354, in loads
>     return _default_decoder.decode(s)
>   File "/opt/conda/envs/py36/lib/python3.6/json/decoder.py", line 342, in decode
>     raise JSONDecodeError("Extra data", s, end)
> json.decoder.JSONDecodeError: Extra data: line 253 column 1 (char 6218)




3. Version 1.11 of the NVidia device plugin was deleted, so I bumped it to 1.12. Error was:
> error: unable to read URL "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.11/nvidia-device-plugin.yml", server reported 404 Not Found, status code=404
